### PR TITLE
fix: banner variable replacement

### DIFF
--- a/config/docker-entrypoint.sh
+++ b/config/docker-entrypoint.sh
@@ -22,8 +22,9 @@ cp "$FS_INSTALLDIR/.version" "$FS_BASEDIR/.version"
 sed -i 's/cms\.ftp\.version/'"$FS_VERSION_SHORT"'/g' $FS_INSTALLDIR/banner.txt
 sed -i 's/cms\.version/'"$FS_VERSION"'/g' $FS_INSTALLDIR/banner.txt
 sed -i 's/jdk\.version/'"$JAVA_VERSION"'/g' $FS_INSTALLDIR/banner.txt
+cp "$FS_INSTALLDIR/banner.txt" "$FS_BASEDIR/banner.txt"
 
-cat /opt/firstspirit5/banner.txt
+cat $FS_BASEDIR/banner.txt
 
 # Clean stalled PIDs
 if [ "$1" = 'start' -a -f /opt/firstspirit5/run/fs-server.pid ];


### PR DESCRIPTION
the entrypoint was displaying the banner from the hardcoded /opt/firstspirit5 path (which is $FS_BASEDIR), but only the the file is $FS_INSTALLDIR is having its variables replaced.
this replaces the bainner in $FS_BASEDIR with the newly replaced one from $FS_INSTALLDIR.
the cat command is updated to use the $FS_BASEDIR variable for clarity.

(side note, I noticed that the $FS_BASEDIR variable isnt used throught this file and will prepare an additional PR for that)