### PR TITLE
fix: remove hardcoded fs_basedir from scripts

### DIFF
--- a/config/check-status.sh
+++ b/config/check-status.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 # See https://docs.e-spirit.com/odfs/edocs/admi/firstspirit-ser/unix/index.html#runlevel
-while ! grep -Fxq "$1" /opt/firstspirit5/.fs.lock; do
-        state=$(sed -n '1p' /opt/firstspirit5/.fs.lock)
+while ! grep -Fxq "$1" $FS_BASEDIR/.fs.lock; do
+        state=$(sed -n '1p' $FS_BASEDIR/.fs.lock)
         echo "State is $state"
         sleep 10;
 done

--- a/config/docker-entrypoint.sh
+++ b/config/docker-entrypoint.sh
@@ -22,8 +22,9 @@ cp "$FS_INSTALLDIR/.version" "$FS_BASEDIR/.version"
 sed -i 's/cms\.ftp\.version/'"$FS_VERSION_SHORT"'/g' $FS_INSTALLDIR/banner.txt
 sed -i 's/cms\.version/'"$FS_VERSION"'/g' $FS_INSTALLDIR/banner.txt
 sed -i 's/jdk\.version/'"$JAVA_VERSION"'/g' $FS_INSTALLDIR/banner.txt
+cp "$FS_INSTALLDIR/banner.txt" "$FS_BASEDIR/banner.txt"
 
-cat /opt/firstspirit5/banner.txt
+cat $FS_BASEDIR/banner.txt
 
 # Clean stalled PIDs
 if [ "$1" = 'start' -a -f /opt/firstspirit5/run/fs-server.pid ];

--- a/config/docker-entrypoint.sh
+++ b/config/docker-entrypoint.sh
@@ -27,41 +27,41 @@ cp "$FS_INSTALLDIR/banner.txt" "$FS_BASEDIR/banner.txt"
 cat $FS_BASEDIR/banner.txt
 
 # Clean stalled PIDs
-if [ "$1" = 'start' -a -f /opt/firstspirit5/run/fs-server.pid ];
+if [ "$1" = 'start' -a -f $FS_BASEDIR/run/fs-server.pid ];
     then
-        rm /opt/firstspirit5/run/fs-server.pid;
+        rm $FS_BASEDIR/run/fs-server.pid;
 fi
 
 # Take ownership for fs5 user
 echo "Taking care fs user owns firstspirit5 directory"
-chown -R fs:fs /opt/firstspirit5
+chown -R fs:fs $FS_BASEDIR
 
 # Check if folders are mounted into container
-if [ -d "/opt/firstspirit5/conf" ]
+if [ -d "$FS_BASEDIR/conf" ]
     then
         echo "Found firstspirit conf directory"
     else
         echo "No firstspirit conf directory found"
 fi
-if [ -d "/opt/firstspirit5/data" ]
+if [ -d "$FS_BASEDIR/data" ]
     then
         echo "Found firstspirit data directory"
     else
         echo "No firstspirit data directory found"
 fi
-if [ -d "/opt/firstspirit5/web" ]
+if [ -d "$FS_BASEDIR/web" ]
     then
         echo "Found firstspirit web directory"
     else
         echo "No firstspirit web directory found"
 fi
-if [ -d "/opt/firstspirit5/export" ]
+if [ -d "$FS_BASEDIR/export" ]
     then
         echo "Found firstspirit export directory"
     else
         echo "No firstspirit export directory found"
 fi
-if [ -d "/opt/firstspirit5/log" ]
+if [ -d "$FS_BASEDIR/log" ]
     then
         echo "Found firstspirit log directory"
     else
@@ -70,13 +70,13 @@ fi
 
 # inject the external hostname if it exists
 if [ -n "$EXT_HOSTNAME" ]; then
-  sed -i "7i URL=$EXT_HOSTNAME" /opt/firstspirit5/conf/fs-server.conf
+  sed -i "7i URL=$EXT_HOSTNAME" $FS_BASEDIR/conf/fs-server.conf
   echo "URL=$EXT_HOSTNAME written to fs-server.conf"
 fi
 
 # inject the external port if it exists
 if [ -n "$EXT_PORT" ]; then
-  sed -i "s/^HTTP_PORT=.*/HTTP_PORT=$EXT_PORT/" /opt/firstspirit5/conf/fs-server.conf
+  sed -i "s/^HTTP_PORT=.*/HTTP_PORT=$EXT_PORT/" $FS_BASEDIR/conf/fs-server.conf
   echo "HTTP_PORT=$EXT_PORT written to fs-server.conf"
 fi
 
@@ -85,6 +85,6 @@ mkdir -p /opt/www/html
 chown -R fs:fs /opt/www
 
 # Run FirstSpirit
-su fs -c "/opt/firstspirit5/bin/fs-server $*"
+su fs -c "$FS_BASEDIR/bin/fs-server $*"
 
-exec tail -F /opt/firstspirit5/log/fs-wrapper.log /opt/firstspirit5/log/fs-server.log
+exec tail -F $FS_BASEDIR/log/fs-wrapper.log $FS_BASEDIR/log/fs-server.log

--- a/config/health-check.sh
+++ b/config/health-check.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-fileName="/opt/firstspirit5/.fs.lock"
+fileName="$FS_BASEDIR/.fs.lock"
 
 # Check if lockfile exists
 test -f $fileName || exit 1


### PR DESCRIPTION
this builds on #74 and replaces the hardcoded /opt/firstspirit5 usages to use the $FS_BASEDIR variable instead 