### PR TITLE
Fix ungraceful container shutdown in docker-entrypoint.sh

### DIFF
--- a/config/docker-entrypoint.sh
+++ b/config/docker-entrypoint.sh
@@ -87,4 +87,17 @@ chown -R fs:fs /opt/www
 # Run FirstSpirit
 su fs -c "$FS_BASEDIR/bin/fs-server $*"
 
-exec tail -F $FS_BASEDIR/log/fs-wrapper.log $FS_BASEDIR/log/fs-server.log
+stop_firstspirit() {
+    echo "Received $1, stopping FirstSpirit gracefully..."
+    su fs -c "$FS_BASEDIR/bin/fs-server stop"
+    kill "$TAIL_PID" 2>/dev/null
+    wait "$TAIL_PID" 2>/dev/null
+    exit 0
+}
+
+trap 'stop_firstspirit TERM' TERM
+trap 'stop_firstspirit INT' INT
+
+tail -F "$FS_BASEDIR/log/fs-wrapper.log" "$FS_BASEDIR/log/fs-server.log" &
+TAIL_PID=$!
+wait "$TAIL_PID"

--- a/config/docker-entrypoint.sh
+++ b/config/docker-entrypoint.sh
@@ -88,6 +88,7 @@ chown -R fs:fs /opt/www
 su fs -c "$FS_BASEDIR/bin/fs-server $*"
 
 stop_firstspirit() {
+    set +e
     echo "Received $1, stopping FirstSpirit gracefully..."
     su fs -c "$FS_BASEDIR/bin/fs-server stop"
     kill "$TAIL_PID" 2>/dev/null


### PR DESCRIPTION
Replace 'exec tail -F' with a background tail and POSIX trap so that SIGTERM/SIGINT triggers a graceful 'fs-server stop' before the container exits, instead of killing the FirstSpirit JVM via SIGKILL.