### PR TITLE
Allow read-only volume mounts by tolerating chown failures in entrypoint

### DIFF
--- a/config/docker-entrypoint.sh
+++ b/config/docker-entrypoint.sh
@@ -34,7 +34,7 @@ fi
 
 # Take ownership for fs5 user
 echo "Taking care fs user owns firstspirit5 directory"
-chown -R fs:fs $FS_BASEDIR
+chown -R fs:fs $FS_BASEDIR 2>&1 || true
 
 # Check if folders are mounted into container
 if [ -d "$FS_BASEDIR/conf" ]


### PR DESCRIPTION
fixes #110